### PR TITLE
fix(TypesService): support index modules

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,8 @@
-module.exports = {
+/** @type {import('jest').Config} */
+const config = {
   transform: {
-    '^.+\\.(t|j)sx?$': '@swc/jest',
+    '^.+\\.(m?t|j)sx?$': '@swc/jest',
   },
 }
+
+module.exports = config

--- a/package.json
+++ b/package.json
@@ -63,8 +63,9 @@
     "type-fest": "^4.10.0"
   },
   "scripts": {
-    "test": "jest",
-    "test:ci": "pnpm run test --ci",
+    "test": "jest --testPathIgnorePatterns=e2e",
+    "test-e2e": "pnpm run build && jest --testPathPattern=e2e",
+    "test:ci": "pnpm run test --ci && pnpm run test-e2e --ci",
     "postinstall": "husky install",
     "build": "tsup",
     "build:check": "attw --pack ./dist",

--- a/tests/TypesService.test.ts
+++ b/tests/TypesService.test.ts
@@ -35,7 +35,10 @@ describe('relative import remapping', () => {
             undefined,
             undefined,
           )
-          const transformed = Types.rewriteRelativeImportSpecifier(rewrite)(testNode)
+          const transformed = Types.rewriteRelativeImportSpecifier(
+            rewrite,
+            (importPath, _sourceFile) => importPath,
+          )(testNode)
           const result = printNode(transformed)
           expect(result).toBe(`import("../index.${ext}")`)
         })
@@ -46,7 +49,10 @@ describe('relative import remapping', () => {
             undefined,
             undefined,
           )
-          const transformed = Types.rewriteRelativeImportSpecifier(rewrite)(testNode)
+          const transformed = Types.rewriteRelativeImportSpecifier(
+            rewrite,
+            (importPath, _sourceFile) => importPath,
+          )(testNode)
           const result = printNode(transformed)
           expect(result).toBe(`import("../index.${ext}")`)
         })
@@ -59,7 +65,10 @@ describe('relative import remapping', () => {
             undefined,
             undefined,
           )
-          const transformed = Types.rewriteRelativeImportSpecifier(rewrite)(testNode)
+          const transformed = Types.rewriteRelativeImportSpecifier(
+            rewrite,
+            (importPath, _sourceFile) => importPath,
+          )(testNode)
           const result = printNode(transformed)
           expect(result).toBe(`import("../../../../index.${ext}")`)
         })
@@ -70,7 +79,10 @@ describe('relative import remapping', () => {
             undefined,
             undefined,
           )
-          const transformed = Types.rewriteRelativeImportSpecifier(rewrite)(testNode)
+          const transformed = Types.rewriteRelativeImportSpecifier(
+            rewrite,
+            (importPath, _sourceFile) => importPath,
+          )(testNode)
           const result = printNode(transformed)
           expect(result).toBe(`import("./index.${ext}")`)
         })
@@ -91,7 +103,10 @@ describe('relative import remapping', () => {
           ),
           ts.factory.createStringLiteral('./foo'),
         )
-        const transformed = Types.rewriteRelativeImportSpecifier(rewrite)(testNode)
+        const transformed = Types.rewriteRelativeImportSpecifier(
+          rewrite,
+          (importPath, _sourceFile) => importPath,
+        )(testNode)
         const result = printNode(transformed)
         expect(result).toBe(`import { type foo } from "./foo.${ext}";`)
       })
@@ -105,7 +120,10 @@ describe('relative import remapping', () => {
           ),
           ts.factory.createStringLiteral('./foo'),
         )
-        const transformed = Types.rewriteRelativeImportSpecifier(rewrite)(testNode)
+        const transformed = Types.rewriteRelativeImportSpecifier(
+          rewrite,
+          (importPath, _sourceFile) => importPath,
+        )(testNode)
         const result = printNode(transformed)
         expect(result).toBe(`import * as foo from "./foo.${ext}";`)
       })
@@ -119,7 +137,10 @@ describe('relative import remapping', () => {
           ),
           ts.factory.createStringLiteral('./foo'),
         )
-        const transformed = Types.rewriteRelativeImportSpecifier(rewrite)(testNode)
+        const transformed = Types.rewriteRelativeImportSpecifier(
+          rewrite,
+          (importPath, _sourceFile) => importPath,
+        )(testNode)
         const result = printNode(transformed)
         expect(result).toBe(`import foo from "./foo.${ext}";`)
       })
@@ -129,7 +150,10 @@ describe('relative import remapping', () => {
           undefined,
           ts.factory.createStringLiteral('./foo'),
         )
-        const transformed = Types.rewriteRelativeImportSpecifier(rewrite)(testNode)
+        const transformed = Types.rewriteRelativeImportSpecifier(
+          rewrite,
+          importPath => importPath,
+        )(testNode)
         const result = printNode(transformed)
         expect(result).toBe(`import "./foo.${ext}";`)
       })
@@ -140,7 +164,10 @@ describe('relative import remapping', () => {
           undefined,
           undefined,
         )
-        const transformed = Types.rewriteRelativeImportSpecifier(rewrite)(testNode)
+        const transformed = Types.rewriteRelativeImportSpecifier(
+          rewrite,
+          (importPath, _sourceFile) => importPath,
+        )(testNode)
         const result = printNode(transformed)
         expect(result).toBe(`import("./foo.${ext}")`)
       })
@@ -150,7 +177,10 @@ describe('relative import remapping', () => {
           ts.factory.createIdentifier('./foo'),
           ts.factory.createModuleBlock([]),
         )
-        const transformed = Types.rewriteRelativeImportSpecifier(rewrite)(testNode)
+        const transformed = Types.rewriteRelativeImportSpecifier(
+          rewrite,
+          (importPath, _sourceFile) => importPath,
+        )(testNode)
         const result = printNode(transformed)
         expect(result).toBe(`declare module "./foo.${ext}" { }`)
       })
@@ -161,7 +191,10 @@ describe('relative import remapping', () => {
           undefined,
           ts.factory.createStringLiteral('./foo'),
         )
-        const transformed = Types.rewriteRelativeImportSpecifier(rewrite)(testNode)
+        const transformed = Types.rewriteRelativeImportSpecifier(
+          rewrite,
+          (importPath, _sourceFile) => importPath,
+        )(testNode)
         const result = printNode(transformed)
         expect(result).toBe(`export type * from "./foo.${ext}";`)
       })
@@ -172,7 +205,10 @@ describe('relative import remapping', () => {
           ts.factory.createNamespaceExport(ts.factory.createIdentifier('foo')),
           ts.factory.createStringLiteral('./foo'),
         )
-        const transformed = Types.rewriteRelativeImportSpecifier(rewrite)(testNode)
+        const transformed = Types.rewriteRelativeImportSpecifier(
+          rewrite,
+          (importPath, _sourceFile) => importPath,
+        )(testNode)
         const result = printNode(transformed)
         expect(result).toBe(`export * as foo from "./foo.${ext}";`)
       })
@@ -185,7 +221,10 @@ describe('relative import remapping', () => {
           ]),
           ts.factory.createStringLiteral('./foo'),
         )
-        const transformed = Types.rewriteRelativeImportSpecifier(rewrite)(testNode)
+        const transformed = Types.rewriteRelativeImportSpecifier(
+          rewrite,
+          (importPath, _sourceFile) => importPath,
+        )(testNode)
         const result = printNode(transformed)
         expect(result).toBe(`export { type foo as foo2 } from "./foo.${ext}";`)
       })

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -1,0 +1,28 @@
+import { exec } from 'node:child_process'
+import path from 'node:path'
+import { promisify } from 'node:util'
+
+// import { makeConfig } from '../src'
+
+describe('test projects', () => {
+  test('index-ref', async () => {
+    await promisify(exec)('npm install', {
+      cwd: path.join(__dirname, 'test-projects/index-ref'),
+    })
+
+    await promisify(exec)('npx tsup', {
+      cwd: path.join(__dirname, 'test-projects/index-ref'),
+    })
+
+    await new Promise<void>((resolve, reject) => {
+      const attw = exec('npx attw --pack .', {
+        cwd: path.join(__dirname, 'test-projects/index-ref/dist'),
+      })
+      attw.stdout?.on('data', data => console.log(data))
+      attw.on('close', code => {
+        if (code === 0) resolve()
+        else reject('attw failed')
+      })
+    })
+  }, 10000)
+})

--- a/tests/test-projects/.gitignore
+++ b/tests/test-projects/.gitignore
@@ -1,0 +1,2 @@
+**/dist
+package-lock.json

--- a/tests/test-projects/index-ref/package.json
+++ b/tests/test-projects/index-ref/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "index-ref",
+  "version": "0.0.1",
+  "devDependencies": {
+    "@fp-tx/build-tools": "file:../../../dist"
+  }
+}

--- a/tests/test-projects/index-ref/src/bar/index.ts
+++ b/tests/test-projects/index-ref/src/bar/index.ts
@@ -1,0 +1,1 @@
+export const baz = 3

--- a/tests/test-projects/index-ref/src/foo.ts
+++ b/tests/test-projects/index-ref/src/foo.ts
@@ -1,0 +1,1 @@
+export * from './bar'

--- a/tests/test-projects/index-ref/tsconfig.json
+++ b/tests/test-projects/index-ref/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "target": "ESNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": false,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": []
+  },
+  "include": ["src/foo.ts", "src/bar/index.ts"],
+  "exclude": []
+}

--- a/tests/test-projects/index-ref/tsup.config.js
+++ b/tests/test-projects/index-ref/tsup.config.js
@@ -1,0 +1,16 @@
+import { makeConfig } from '@fp-tx/build-tools'
+
+export default makeConfig(
+  {
+    basePath: '.',
+    buildType: 'dual',
+    buildMode: {
+      type: 'Single',
+      entrypoint: 'foo.ts',
+    },
+    srcDir: './src',
+    outDir: './dist',
+    copyFiles: [],
+  },
+  {},
+)

--- a/tests/test-projects/readme.md
+++ b/tests/test-projects/readme.md
@@ -1,0 +1,1 @@
+This directory is for small projects to test the build.


### PR DESCRIPTION
This makes.. some progress towards fixing implicit references to index files.

Specifically, an import like this:

```ts
import * as foo from './foo'
```

Would always get transformed in the .d.(m)ts files into this:

```ts
import * as foo from './foo.(m)js'
```

But this is a problem if foo is actually a directory with an index file, like this:

```
- bar.ts       // the file with the './foo' import
- foo/
  - index.ts
```

This attempts to resolve the issue by _also_ checking if the module resolved by the importPath is an index module, and if so, _not_ transforming the import at all.

As is, this doesn't work 100% -- still getting a `node16 (from ESM): 🥴 Internal resolution error` from ATTW. ~~Not sure why that is, though~~ evidently, ESM requires a full expansion, so for that case it should be `./foo/index.js`