### PR TITLE
feat(workspaces): preserve d.(c|m)ts directory structure

### DIFF
--- a/src/ExportsService.ts
+++ b/src/ExportsService.ts
@@ -7,6 +7,7 @@ import * as RR from 'fp-ts/lib/ReadonlyRecord.js'
 import * as Sg from 'fp-ts/lib/Semigroup.js'
 import * as Str from 'fp-ts/lib/string.js'
 import * as TE from 'fp-ts/lib/TaskEither.js'
+import path from 'path'
 import { type PackageJson } from 'type-fest'
 
 import * as Config from './ConfigService'
@@ -77,9 +78,12 @@ const tsToGlobal = (file: string): string => './' + file.replace(/\.tsx?$/, '.gl
 const tsToGlobalCjs = (file: string): string =>
   './' + file.replace(/\.tsx?$/, '.global.cjs')
 const tsToMjs = (file: string): string => './' + file.replace(/\.tsx?$/, '.mjs')
-const tsToDts = (file: string): string => './' + file.replace(/\.tsx?$/, '.d.ts')
-const tsToDmts = (file: string): string => './' + file.replace(/\.tsx?$/, '.d.mts')
-const tsToDcts = (file: string): string => './' + file.replace(/\.tsx?$/, '.d.cts')
+const tsToDts = (config: Required<Config.ConfigParameters>, file: string): string =>
+  './' + path.join(config.srcDir, file.replace(/\.tsx?$/, '.d.ts'))
+const tsToDmts = (config: Required<Config.ConfigParameters>, file: string): string =>
+  './' + path.join(config.srcDir, file.replace(/\.tsx?$/, '.d.mts'))
+const tsToDcts = (config: Required<Config.ConfigParameters>, file: string): string =>
+  './' + path.join(config.srcDir, file.replace(/\.tsx?$/, '.d.cts'))
 
 const exportKey = (indexFile: string, file: string): string =>
   file === indexFile ? '.' : `./${stripExtension(file)}`
@@ -103,17 +107,17 @@ type DefaultExports = {
 const addDtsExports = (
   config: Required<Config.ConfigParameters>,
   file: string,
-): TypesExports => (config.emitTypes ? { types: tsToDts(file) } : {})
+): TypesExports => (config.emitTypes ? { types: tsToDts(config, file) } : {})
 
 const addDmtsExports = (
   config: Required<Config.ConfigParameters>,
   file: string,
-): TypesExports => (config.emitTypes ? { types: tsToDmts(file) } : {})
+): TypesExports => (config.emitTypes ? { types: tsToDmts(config, file) } : {})
 
 const addDctsExports = (
   config: Required<Config.ConfigParameters>,
   file: string,
-): TypesExports => (config.emitTypes ? { types: tsToDcts(file) } : {})
+): TypesExports => (config.emitTypes ? { types: tsToDcts(config, file) } : {})
 
 type ToExports = {
   readonly types: (

--- a/src/TypesService.ts
+++ b/src/TypesService.ts
@@ -261,6 +261,7 @@ const sharedConfig = (host: RealFileSystemHost) =>
               declaration: true,
               declarationMap: true,
               noEmit: false,
+              rootDir: config.basePath,
               outDir: path.join(config.basePath, config.outDir),
               moduleResolution: ts.ModuleResolutionKind.Node16,
               module: ts.ModuleKind.Node16,

--- a/tests/ExportsService.test.ts
+++ b/tests/ExportsService.test.ts
@@ -23,14 +23,14 @@ describe('ExportsService', () => {
       tuple(
         {
           '.': {
-            import: { types: './foo.d.ts', default: './foo.js' },
-            require: { types: './foo.d.cts', default: './foo.cjs' },
+            import: { types: './src/foo.d.ts', default: './foo.js' },
+            require: { types: './src/foo.d.cts', default: './foo.cjs' },
           },
           './package.json': './package.json',
         },
         './foo.cjs',
         './foo.js',
-        './foo.d.cts',
+        './src/foo.d.cts',
       ),
     ),
     tuple(
@@ -49,22 +49,22 @@ describe('ExportsService', () => {
       tuple(
         {
           '.': {
-            import: { types: './foo.d.ts', default: './foo.js' },
-            require: { types: './foo.d.cts', default: './foo.cjs' },
+            import: { types: './src/foo.d.ts', default: './foo.js' },
+            require: { types: './src/foo.d.cts', default: './foo.cjs' },
           },
           './foo.a': {
-            import: { types: './foo.a.d.ts', default: './foo.a.js' },
-            require: { types: './foo.a.d.cts', default: './foo.a.cjs' },
+            import: { types: './src/foo.a.d.ts', default: './foo.a.js' },
+            require: { types: './src/foo.a.d.cts', default: './foo.a.cjs' },
           },
           './foo.b': {
-            import: { types: './foo.b.d.ts', default: './foo.b.js' },
-            require: { types: './foo.b.d.cts', default: './foo.b.cjs' },
+            import: { types: './src/foo.b.d.ts', default: './foo.b.js' },
+            require: { types: './src/foo.b.d.cts', default: './foo.b.cjs' },
           },
           './package.json': './package.json',
         },
         './foo.cjs',
         './foo.js',
-        './foo.d.cts',
+        './src/foo.d.cts',
       ),
     ),
     tuple(
@@ -79,14 +79,14 @@ describe('ExportsService', () => {
       tuple(
         {
           '.': {
-            import: { types: './foo.d.mts', default: './foo.mjs' },
-            require: { types: './foo.d.ts', default: './foo.js' },
+            import: { types: './src/foo.d.mts', default: './foo.mjs' },
+            require: { types: './src/foo.d.ts', default: './foo.js' },
           },
           './package.json': './package.json',
         },
         './foo.js',
         './foo.mjs',
-        './foo.d.ts',
+        './src/foo.d.ts',
       ),
     ),
     tuple(
@@ -105,22 +105,22 @@ describe('ExportsService', () => {
       tuple(
         {
           '.': {
-            import: { types: './foo.d.mts', default: './foo.mjs' },
-            require: { types: './foo.d.ts', default: './foo.js' },
+            import: { types: './src/foo.d.mts', default: './foo.mjs' },
+            require: { types: './src/foo.d.ts', default: './foo.js' },
           },
           './foo.a': {
-            import: { types: './foo.a.d.mts', default: './foo.a.mjs' },
-            require: { types: './foo.a.d.ts', default: './foo.a.js' },
+            import: { types: './src/foo.a.d.mts', default: './foo.a.mjs' },
+            require: { types: './src/foo.a.d.ts', default: './foo.a.js' },
           },
           './foo.b': {
-            import: { types: './foo.b.d.mts', default: './foo.b.mjs' },
-            require: { types: './foo.b.d.ts', default: './foo.b.js' },
+            import: { types: './src/foo.b.d.mts', default: './foo.b.mjs' },
+            require: { types: './src/foo.b.d.ts', default: './foo.b.js' },
           },
           './package.json': './package.json',
         },
         './foo.js',
         './foo.mjs',
-        './foo.d.ts',
+        './src/foo.d.ts',
       ),
     ),
     tuple(
@@ -136,13 +136,13 @@ describe('ExportsService', () => {
       tuple(
         {
           '.': {
-            require: { types: './foo.d.cts', default: './foo.cjs' },
+            require: { types: './src/foo.d.cts', default: './foo.cjs' },
           },
           './package.json': './package.json',
         },
         './foo.cjs',
         undefined,
-        './foo.d.cts',
+        './src/foo.d.cts',
       ),
     ),
     tuple(
@@ -162,19 +162,19 @@ describe('ExportsService', () => {
       tuple(
         {
           '.': {
-            require: { types: './foo.d.cts', default: './foo.cjs' },
+            require: { types: './src/foo.d.cts', default: './foo.cjs' },
           },
           './foo.a': {
-            require: { types: './foo.a.d.cts', default: './foo.a.cjs' },
+            require: { types: './src/foo.a.d.cts', default: './foo.a.cjs' },
           },
           './foo.b': {
-            require: { types: './foo.b.d.cts', default: './foo.b.cjs' },
+            require: { types: './src/foo.b.d.cts', default: './foo.b.cjs' },
           },
           './package.json': './package.json',
         },
         './foo.cjs',
         undefined,
-        './foo.d.cts',
+        './src/foo.d.cts',
       ),
     ),
     tuple(
@@ -190,13 +190,13 @@ describe('ExportsService', () => {
       tuple(
         {
           '.': {
-            require: { types: './foo.d.ts', default: './foo.js' },
+            require: { types: './src/foo.d.ts', default: './foo.js' },
           },
           './package.json': './package.json',
         },
         './foo.js',
         undefined,
-        './foo.d.ts',
+        './src/foo.d.ts',
       ),
     ),
     tuple(
@@ -216,19 +216,19 @@ describe('ExportsService', () => {
       tuple(
         {
           '.': {
-            require: { types: './foo.d.ts', default: './foo.js' },
+            require: { types: './src/foo.d.ts', default: './foo.js' },
           },
           './foo.a': {
-            require: { types: './foo.a.d.ts', default: './foo.a.js' },
+            require: { types: './src/foo.a.d.ts', default: './foo.a.js' },
           },
           './foo.b': {
-            require: { types: './foo.b.d.ts', default: './foo.b.js' },
+            require: { types: './src/foo.b.d.ts', default: './foo.b.js' },
           },
           './package.json': './package.json',
         },
         './foo.js',
         undefined,
-        './foo.d.ts',
+        './src/foo.d.ts',
       ),
     ),
     tuple(
@@ -244,13 +244,13 @@ describe('ExportsService', () => {
       tuple(
         {
           '.': {
-            import: { types: './foo.d.mts', default: './foo.mjs' },
+            import: { types: './src/foo.d.mts', default: './foo.mjs' },
           },
           './package.json': './package.json',
         },
         undefined,
         './foo.mjs',
-        './foo.d.mts',
+        './src/foo.d.mts',
       ),
     ),
     tuple(
@@ -270,19 +270,19 @@ describe('ExportsService', () => {
       tuple(
         {
           '.': {
-            import: { types: './foo.d.mts', default: './foo.mjs' },
+            import: { types: './src/foo.d.mts', default: './foo.mjs' },
           },
           './foo.a': {
-            import: { types: './foo.a.d.mts', default: './foo.a.mjs' },
+            import: { types: './src/foo.a.d.mts', default: './foo.a.mjs' },
           },
           './foo.b': {
-            import: { types: './foo.b.d.mts', default: './foo.b.mjs' },
+            import: { types: './src/foo.b.d.mts', default: './foo.b.mjs' },
           },
           './package.json': './package.json',
         },
         undefined,
         './foo.mjs',
-        './foo.d.mts',
+        './src/foo.d.mts',
       ),
     ),
     tuple(
@@ -298,13 +298,13 @@ describe('ExportsService', () => {
       tuple(
         {
           '.': {
-            import: { types: './foo.d.ts', default: './foo.js' },
+            import: { types: './src/foo.d.ts', default: './foo.js' },
           },
           './package.json': './package.json',
         },
         undefined,
         './foo.js',
-        './foo.d.ts',
+        './src/foo.d.ts',
       ),
     ),
     tuple(
@@ -324,19 +324,19 @@ describe('ExportsService', () => {
       tuple(
         {
           '.': {
-            import: { types: './foo.d.ts', default: './foo.js' },
+            import: { types: './src/foo.d.ts', default: './foo.js' },
           },
           './foo.a': {
-            import: { types: './foo.a.d.ts', default: './foo.a.js' },
+            import: { types: './src/foo.a.d.ts', default: './foo.a.js' },
           },
           './foo.b': {
-            import: { types: './foo.b.d.ts', default: './foo.b.js' },
+            import: { types: './src/foo.b.d.ts', default: './foo.b.js' },
           },
           './package.json': './package.json',
         },
         undefined,
         './foo.js',
-        './foo.d.ts',
+        './src/foo.d.ts',
       ),
     ),
   ])('%s', async (_, configService, service, expected) => {


### PR DESCRIPTION
I ran into an issue with TypeScript in a workspace / composite TSconfig settting where TS needed the root-directory specified.  This meant that all emitted declaration files were emitted with a preserved structure, i.e. inside of the source directory.  This cleaned up the output quite substantially, where dist files contain plain javascript, and dts and ts files from src are colocated in the dist/src directory.  

_Note for library authors_:

This will not produce any breaking changes with your library unless you're incidentally doing some post-processing after the fact, but note the caveat below.

If you publish from `dist` upgrading to 0.5.0 there is nothing you need to do.  If you publish from `.` you will need to adjust your type exports to point to `./dist/src/...` instead. 