### PR TITLE
feat(dts): strip internal by default, add dts compiler overrides option

### DIFF
--- a/src/ConfigService.ts
+++ b/src/ConfigService.ts
@@ -2,6 +2,7 @@ import { pipe } from 'fp-ts/lib/function.js'
 import type * as R from 'fp-ts/lib/Reader.js'
 import * as RTE from 'fp-ts/lib/ReaderTaskEither.js'
 import { type PackageJson } from 'type-fest'
+import { type CompilerOptions } from 'typescript'
 
 const ConfigServiceSymbol = Symbol('ConfigService')
 
@@ -107,6 +108,18 @@ export type ConfigParameters = {
    * @default 'dist'
    */
   readonly outDir?: string
+
+  /**
+   * Options that override build-tools type options when compiling TypeScript declaration
+   * files.
+   *
+   * @remarks
+   *   **Do not use this option unless you are certain you know what you're doing.**
+   *   Build-tools chooses the best options for library development, and overriding these
+   *   could cause unpredictable behavior.
+   * @default { }
+   */
+  readonly dtsCompilerOverrides?: Partial<CompilerOptions>
 }
 
 export class ConfigService {
@@ -122,6 +135,7 @@ export class ConfigService {
     buildMode = { type: 'Single', entrypoint: 'index.ts' },
     emitTypes = true,
     dtsConfig = 'tsconfig.json',
+    dtsCompilerOverrides = {},
   }: ConfigParameters) {
     this[ConfigServiceSymbol] = {
       buildType,
@@ -134,6 +148,7 @@ export class ConfigService {
       iife,
       buildMode,
       emitTypes,
+      dtsCompilerOverrides,
     }
   }
 }

--- a/src/TypesService.ts
+++ b/src/TypesService.ts
@@ -266,6 +266,8 @@ const sharedConfig = (host: RealFileSystemHost) =>
               moduleResolution: ts.ModuleResolutionKind.Node16,
               module: ts.ModuleKind.Node16,
               target: ts.ScriptTarget.ESNext,
+              stripInternal: true,
+              ...config.dtsCompilerOverrides,
             },
             fileSystem: host,
           }),


### PR DESCRIPTION
## Changes

- Now TypeScript will strip anything marked with the `@internal` jsdoc tag.  See the [relevant documentation](https://www.typescriptlang.org/tsconfig/#stripInternal).
- There is now an available config option to override compiler options.  Do not use this option unless you know what you are doing.

## Note to library authors

If you use the `@internal` JSDoc tag, **this will likely result in a breaking change** for your library as those types will no longer be included in the final output.  

If you wish to continue including those internal types as to avoid a breaking change, pass the following to the configuration which will override the new default option.

```js
{
  dtsCompilerOverrides: {
    stripInternal: false
  }
}
```

## A word of caution

If one of your exports depends on something that is marked with an `@internal` tag, this will result in an error during type compilation.  This should be caught during [lib-check](https://www.typescriptlang.org/tsconfig/#skipLibCheck), so do not disable that option.