### PR TITLE
fix: prevent types field from being overidden

### DIFF
--- a/src/BuildService.ts
+++ b/src/BuildService.ts
@@ -159,6 +159,7 @@ export const BuildServiceLive: RTE.ReaderTaskEither<
         main: _,
         module: __,
         exports: ___,
+        types: ____,
         ...rest
       },
     }) =>

--- a/tests/test-projects/jsx/package.json
+++ b/tests/test-projects/jsx/package.json
@@ -1,6 +1,10 @@
 {
   "name": "jsx",
   "version": "0.0.1",
+  "types": "./this/folder/doesn-t/exist.d.ts",
+  "main": "./this/folder/also/doesn-t/exit/index.js",
+  "module": "./this/folder/exists/jk.mjs",
+  "exports": "./just-wrong.cjs",
   "devDependencies": {
     "@fp-tx/build-tools": "file:../../../dist",
     "@types/react": "^18.3.5",


### PR DESCRIPTION
This will prevent a types field in the package json from overriding the emitted package.json from build-tool