### PR TITLE
feat: add support for package bin field

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # build-tools
 
-`@fp-tx/build-tools` is a thin wrapper around `tsup` for the purpose of building dual ESM/CJS packages. It contains a chief export `makeConfig` which will read from a configurable source directory and determine which files to include as entrypoints. Using these entrypoints, it also adds a dynamic "exports" field with `import` and `default` fields based on the determined entrypoints and module type (determined by `package.json > type`).
+`@fp-tx/build-tools` is a thin wrapper around `tsup` for the purpose of building dual ESM/CJS packages. It contains a chief export `makeConfig` which will read from a configurable source directory and determine which files to include as entrypoints. Using these entrypoints, it also adds a dynamic "exports" field with `import` and `default` fields based on the determined entrypoints and module type (determined by `package.json > type`). Additionally it adds the appropriate `main`, `module`, `types`, and `bin` (if applicable) to the emitted package.json.
 
 Additionally, `build-tools` will emit smart declaration files with rewritten import, export, and `declare module` paths.
 
@@ -24,7 +24,7 @@ const config = makeConfig(
     buildType: 'dual',
     buildMode: {
       type: 'Single',
-      entrypoint: 'index.ts',
+      entrypoint: './src/index.ts',
     },
     iife: false,
 
@@ -71,15 +71,17 @@ npm install -D tsup @fp-tx/build-tools
 
 ## Configuration Parameters
 
-| Parameter          | Type                    | Description                                                                                    | Default                                      |
-| ------------------ | ----------------------- | ---------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| iife               | `boolean`               | Include IIFE generation as fallback. This setting is recommended for single-target builds      | `false`                                      |
-| emitTypes          | `boolean`               | Generate `.d.ts`, and `.d.cts` or `.d.mts` files                                               | `true`                                       |
-| dtsConfig          | `string`                | The `tsconfig.json` for types generation                                                       | `tsconfig.json`                              |
-| srcDir             | `string`                | The source directory to read from                                                              | `'src'`                                      |
-| basePath           | `string`                | The current working directory                                                                  | `'.'`                                        |
-| buildMode          | `BuildMode`             | Determines the package entrypoints, "Single" and `entrypoint` or "Multi" and `entrypointGlobs` | `{ type: "Single", entrypoint: "index.ts" }` |
-| buildType          | `cjs`, `esm`, or `dual` | Determines the output module format along with `package.json > type`                           | `dual`                                       |
-| omittedPackageKeys | `ReadonlyArray<string>` | Array of keys to omit from the package.json file                                               | `["devDependencies", "scripts"]`             |
-| copyFiles          | `ReadonlyArray<string>` | Whether to copy non-typescript files                                                           | `['README.md', 'LICENSE']`                   |
-| outDir             | `string`                | The output directory                                                                           | `dist`                                       |
+| Parameter            | Type                                 | Description                                                                                                          | Default                                      |
+| -------------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| iife                 | `boolean`                            | Include IIFE generation as fallback. This setting is recommended for single-target builds                            | `false`                                      |
+| emitTypes            | `boolean`                            | Generate `.d.ts`, and `.d.cts` or `.d.mts` files                                                                     | `true`                                       |
+| dtsConfig            | `string`                             | The `tsconfig.json` for types generation                                                                             | `tsconfig.json`                              |
+| srcDir               | `string`                             | The source directory to read from                                                                                    | `'src'`                                      |
+| basePath             | `string`                             | The current working directory                                                                                        | `'.'`                                        |
+| buildMode            | `BuildMode`                          | Determines the package entrypoints, "Single" and `entrypoint` or "Multi" and `entrypointGlobs`                       | `{ type: "Single", entrypoint: "index.ts" }` |
+| buildType            | `cjs`, `esm`, or `dual`              | Determines the output module format along with `package.json > type`                                                 | `dual`                                       |
+| omittedPackageKeys   | `ReadonlyArray<string>`              | Array of keys to omit from the package.json file                                                                     | `["devDependencies", "scripts"]`             |
+| copyFiles            | `ReadonlyArray<string>`              | Whether to copy non-typescript files                                                                                 | `['README.md', 'LICENSE']`                   |
+| outDir               | `string`                             | The output directory                                                                                                 | `dist`                                       |
+| dtsCompilerOverrides | `Partial<CompilerOptions>`           | Overrides to override build-tools imposed tsconfig defaults. **Only use this option if you know what you are doing** | `{}`                                         |
+| bin                  | `string` or `Record<string, string>` | `ts` file entrypoints to fill the emitted package `bin` field                                                        | `null`                                       |

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "husky": "^8.0.3",
     "jest": "^29.7.0",
     "lint-staged": "^15.1.0",
-    "prettier": "~3.1.0",
+    "prettier": "~3.1.1",
     "prettier-plugin-jsdoc": "^1.1.1",
     "tsc-files": "^1.1.4",
     "tsup": "^8.0.0",
@@ -88,5 +88,10 @@
       "eslint --fix-type layout --fix --cache",
       "pnpm run prerelease"
     ]
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "lru-cache@10.4.3": "patches/lru-cache@10.4.3.patch"
+    }
   }
 }

--- a/patches/lru-cache@10.4.3.patch
+++ b/patches/lru-cache@10.4.3.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/commonjs/index.d.ts b/dist/commonjs/index.d.ts
+index f59de7602a528afde714e56dcf8c25ee496e39fb..804042b5ff381b8594307296de29d31d1b564c92 100644
+--- a/dist/commonjs/index.d.ts
++++ b/dist/commonjs/index.d.ts
+@@ -837,7 +837,7 @@ export declare namespace LRUCache {
+  *
+  * Changing any of these will alter the defaults for subsequent method calls.
+  */
+-export declare class LRUCache<K extends {}, V extends {}, FC = unknown> implements Map<K, V> {
++export declare class LRUCache<K extends {}, V extends {}, FC = unknown> {
+     #private;
+     /**
+      * {@link LRUCache.OptionsBase.ttl}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  lru-cache@10.4.3:
+    hash: hawnkdxmi6fjojy7ubkjvqg3r4
+    path: patches/lru-cache@10.4.3.patch
+
 importers:
 
   .:
@@ -91,7 +96,7 @@ importers:
         specifier: ^15.1.0
         version: 15.1.0
       prettier:
-        specifier: ~3.1.0
+        specifier: ~3.1.1
         version: 3.1.1
       prettier-plugin-jsdoc:
         specifier: ^1.1.1
@@ -5710,7 +5715,7 @@ snapshots:
       strip-ansi: 7.1.0
       wrap-ansi: 8.1.0
 
-  lru-cache@10.4.3: {}
+  lru-cache@10.4.3(patch_hash=hawnkdxmi6fjojy7ubkjvqg3r4): {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -6097,7 +6102,7 @@ snapshots:
 
   path-scurry@1.11.1:
     dependencies:
-      lru-cache: 10.4.3
+      lru-cache: 10.4.3(patch_hash=hawnkdxmi6fjojy7ubkjvqg3r4)
       minipass: 7.1.2
 
   path-type@4.0.0: {}

--- a/src/ConfigService.ts
+++ b/src/ConfigService.ts
@@ -120,6 +120,16 @@ export type ConfigParameters = {
    * @default { }
    */
   readonly dtsCompilerOverrides?: Partial<CompilerOptions>
+
+  /**
+   * Allows you to specify the package-command entrypoints as TypeScript files that will
+   * be re-pointed to their emitted javascript files.
+   *
+   * @remarks
+   *   **Any binary file specified in this key or record must be an entrypoint, an error
+   *   will be raised if that file is excluded from the entrypoint globs**
+   */
+  readonly bin?: string | Record<string, string> | null
 }
 
 export class ConfigService {
@@ -136,6 +146,7 @@ export class ConfigService {
     emitTypes = true,
     dtsConfig = 'tsconfig.json',
     dtsCompilerOverrides = {},
+    bin = null,
   }: ConfigParameters) {
     this[ConfigServiceSymbol] = {
       buildType,
@@ -149,6 +160,7 @@ export class ConfigService {
       buildMode,
       emitTypes,
       dtsCompilerOverrides,
+      bin,
     }
   }
 }

--- a/src/PackageJson.ts
+++ b/src/PackageJson.ts
@@ -16,6 +16,7 @@ export const PackageJsonSchema = S.ParseJsonString(
       module: S.Unknown,
       exports: S.Unknown,
       type: S.Optional(S.Literal('module', 'commonjs'), 'commonjs'),
+      bin: S.Unknown,
     },
     S.Unknown,
   ),

--- a/tests/ExportsService.test.ts
+++ b/tests/ExportsService.test.ts
@@ -12,6 +12,37 @@ function assertRight(e: E.Either<unknown, unknown>): asserts e is E.Right<unknow
 describe('ExportsService', () => {
   test.each([
     tuple(
+      '`bin` field resolution',
+      ConfigServiceLive({
+        buildMode: { type: 'Single', entrypoint: 'foo.ts' },
+        bin: {
+          foo: './foo.ts',
+          bar: './bar.ts',
+        },
+      }),
+      ExportsService.ExportsServiceLive({
+        files: ['foo.ts', 'bar.ts'],
+        type: 'module',
+        resolvedIndex: 'foo.ts',
+      }),
+      tuple(
+        {
+          '.': {
+            import: { types: './foo.d.ts', default: './foo.js' },
+            require: { types: './foo.d.cts', default: './foo.cjs' },
+          },
+          './package.json': './package.json',
+        },
+        './foo.cjs',
+        './foo.js',
+        './foo.d.cts',
+        {
+          foo: './foo.js',
+          bar: './bar.js',
+        },
+      ),
+    ),
+    tuple(
       'Dual "type: module" Single Exports',
       ConfigServiceLive({
         buildMode: { type: 'Single', entrypoint: 'foo.ts' },
@@ -32,6 +63,7 @@ describe('ExportsService', () => {
         './foo.cjs',
         './foo.js',
         './foo.d.cts',
+        undefined,
       ),
     ),
     tuple(
@@ -67,6 +99,7 @@ describe('ExportsService', () => {
         './src/foo.cjs',
         './src/foo.js',
         './src/foo.d.cts',
+        undefined,
       ),
     ),
     tuple(
@@ -90,6 +123,7 @@ describe('ExportsService', () => {
         './foo.js',
         './foo.mjs',
         './foo.d.ts',
+        undefined,
       ),
     ),
     tuple(
@@ -125,6 +159,7 @@ describe('ExportsService', () => {
         './src/foo.js',
         './src/foo.mjs',
         './src/foo.d.ts',
+        undefined,
       ),
     ),
     tuple(
@@ -148,6 +183,7 @@ describe('ExportsService', () => {
         './foo.cjs',
         undefined,
         './foo.d.cts',
+        undefined,
       ),
     ),
     tuple(
@@ -181,6 +217,7 @@ describe('ExportsService', () => {
         './src/foo.cjs',
         undefined,
         './src/foo.d.cts',
+        undefined,
       ),
     ),
     tuple(
@@ -204,6 +241,7 @@ describe('ExportsService', () => {
         './foo.js',
         undefined,
         './foo.d.ts',
+        undefined,
       ),
     ),
     tuple(
@@ -237,6 +275,7 @@ describe('ExportsService', () => {
         './src/foo.js',
         undefined,
         './src/foo.d.ts',
+        undefined,
       ),
     ),
     tuple(
@@ -260,6 +299,7 @@ describe('ExportsService', () => {
         undefined,
         './foo.mjs',
         './foo.d.mts',
+        undefined,
       ),
     ),
     tuple(
@@ -293,6 +333,7 @@ describe('ExportsService', () => {
         undefined,
         './src/foo.mjs',
         './src/foo.d.mts',
+        undefined,
       ),
     ),
     tuple(
@@ -316,6 +357,7 @@ describe('ExportsService', () => {
         undefined,
         './foo.js',
         './foo.d.ts',
+        undefined,
       ),
     ),
     tuple(
@@ -349,6 +391,7 @@ describe('ExportsService', () => {
         undefined,
         './src/foo.js',
         './src/foo.d.ts',
+        undefined,
       ),
     ),
   ])('%s', async (_, configService, service, expected) => {

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -5,8 +5,6 @@ import { promisify } from 'node:util'
 import { pipe } from 'fp-ts/lib/function'
 import * as RA from 'fp-ts/lib/ReadonlyArray'
 
-// import { makeConfig } from '../src'
-
 describe('test projects', () => {
   test.each(
     pipe(
@@ -42,6 +40,10 @@ describe('test projects', () => {
         // Used to test single-entrypoint root based dual libs
         // ------------------------------------------------
         'single-root-dual',
+        // ------------------------------------------------
+        // Used to test usage of the bin field
+        // ------------------------------------------------
+        'bin-cjs-dual',
       ]),
     ),
   )(

--- a/tests/test-projects/bin-cjs-dual/.gitignore
+++ b/tests/test-projects/bin-cjs-dual/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/tests/test-projects/bin-cjs-dual/baz.ts
+++ b/tests/test-projects/bin-cjs-dual/baz.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+export function main2() {
+  console.log('success!')
+}
+
+main2()

--- a/tests/test-projects/bin-cjs-dual/foo.ts
+++ b/tests/test-projects/bin-cjs-dual/foo.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+import { bar } from './src/bar'
+
+export function main() {
+  console.log({ bar })
+}
+
+main()

--- a/tests/test-projects/bin-cjs-dual/package.json
+++ b/tests/test-projects/bin-cjs-dual/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "bin-cjs-dual",
+  "version": "0.0.1",
+  "devDependencies": {
+    "@fp-tx/build-tools": "file:../../../dist"
+  }
+}

--- a/tests/test-projects/bin-cjs-dual/src/bar.ts
+++ b/tests/test-projects/bin-cjs-dual/src/bar.ts
@@ -1,0 +1,2 @@
+/** @public */
+export const bar = 'foo'

--- a/tests/test-projects/bin-cjs-dual/tsconfig.json
+++ b/tests/test-projects/bin-cjs-dual/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "target": "ESNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": false,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": []
+  },
+  "include": ["./src/*.ts", "baz.ts", "foo.ts"],
+  "exclude": []
+}

--- a/tests/test-projects/bin-cjs-dual/tsup.config.js
+++ b/tests/test-projects/bin-cjs-dual/tsup.config.js
@@ -1,0 +1,23 @@
+import { makeConfig } from '@fp-tx/build-tools'
+
+export default makeConfig(
+  {
+    basePath: '.',
+    buildType: 'dual',
+    buildMode: {
+      type: 'Multi',
+      entrypointGlobs: ['./foo.ts', './baz.ts'],
+    },
+    srcDir: './src',
+    outDir: './dist',
+    copyFiles: [],
+    iife: true,
+    bin: {
+      foo: './foo.ts',
+      baz: './baz.ts',
+    },
+  },
+  {
+    clean: true,
+  },
+)


### PR DESCRIPTION
Now it's possible for build-tools to auto-resolve bin-fields from TypeScript files to the emitted package.json.  