### PR TITLE
fix: typescript will now properly typecheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "prettier-plugin-jsdoc": "^1.1.1",
     "tsc-files": "^1.1.4",
     "tsup": "^8.0.0",
-    "typescript": "^5.5.4"
+    "typescript": "^5.6.0"
   },
   "peerDependencies": {
     "tsup": "^8.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         version: 0.13.7
       '@commitlint/cli':
         specifier: ^18.4.3
-        version: 18.4.3(@types/node@20.10.0)(typescript@5.5.4)
+        version: 18.4.3(@types/node@20.10.0)(typescript@5.6.2)
       '@commitlint/config-conventional':
         specifier: ^18.4.3
         version: 18.4.3
@@ -67,22 +67,22 @@ importers:
         version: 20.10.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.11.0
-        version: 6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.5.4))(eslint@8.54.0)(typescript@5.5.4)
+        version: 6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.6.2))(eslint@8.54.0)(typescript@5.6.2)
       '@typescript-eslint/parser':
         specifier: ^6.11.0
-        version: 6.11.0(eslint@8.54.0)(typescript@5.5.4)
+        version: 6.11.0(eslint@8.54.0)(typescript@5.6.2)
       eslint:
         specifier: ^8.54.0
         version: 8.54.0
       eslint-plugin-import:
         specifier: ^2.29.0
-        version: 2.29.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.5.4))(eslint@8.54.0)
+        version: 2.29.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.6.2))(eslint@8.54.0)
       eslint-plugin-simple-import-sort:
         specifier: ^10.0.0
         version: 10.0.0(eslint@8.54.0)
       eslint-plugin-unused-imports:
         specifier: ^3.0.0
-        version: 3.0.0(@typescript-eslint/eslint-plugin@6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.5.4))(eslint@8.54.0)(typescript@5.5.4))(eslint@8.54.0)
+        version: 3.0.0(@typescript-eslint/eslint-plugin@6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.6.2))(eslint@8.54.0)(typescript@5.6.2))(eslint@8.54.0)
       fast-check:
         specifier: ^3.15.1
         version: 3.15.1
@@ -103,13 +103,13 @@ importers:
         version: 1.1.1(prettier@3.1.1)
       tsc-files:
         specifier: ^1.1.4
-        version: 1.1.4(typescript@5.5.4)
+        version: 1.1.4(typescript@5.6.2)
       tsup:
         specifier: ^8.0.0
-        version: 8.0.0(@swc/core@1.3.107)(typescript@5.5.4)
+        version: 8.0.0(@swc/core@1.3.107)(typescript@5.6.2)
       typescript:
-        specifier: ^5.5.4
-        version: 5.5.4
+        specifier: ^5.6.0
+        version: 5.6.2
 
 packages:
 
@@ -3070,8 +3070,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.5.4:
-    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
+  typescript@5.6.2:
+    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -3403,11 +3403,11 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commitlint/cli@18.4.3(@types/node@20.10.0)(typescript@5.5.4)':
+  '@commitlint/cli@18.4.3(@types/node@20.10.0)(typescript@5.6.2)':
     dependencies:
       '@commitlint/format': 18.6.1
       '@commitlint/lint': 18.6.1
-      '@commitlint/load': 18.6.1(@types/node@20.10.0)(typescript@5.5.4)
+      '@commitlint/load': 18.6.1(@types/node@20.10.0)(typescript@5.6.2)
       '@commitlint/read': 18.6.1
       '@commitlint/types': 18.6.1
       execa: 5.1.1
@@ -3456,15 +3456,15 @@ snapshots:
       '@commitlint/rules': 18.6.1
       '@commitlint/types': 18.6.1
 
-  '@commitlint/load@18.6.1(@types/node@20.10.0)(typescript@5.5.4)':
+  '@commitlint/load@18.6.1(@types/node@20.10.0)(typescript@5.6.2)':
     dependencies:
       '@commitlint/config-validator': 18.6.1
       '@commitlint/execute-rule': 18.6.1
       '@commitlint/resolve-extends': 18.6.1
       '@commitlint/types': 18.6.1
       chalk: 4.1.2
-      cosmiconfig: 8.3.6(typescript@5.5.4)
-      cosmiconfig-typescript-loader: 5.0.0(@types/node@20.10.0)(cosmiconfig@8.3.6(typescript@5.5.4))(typescript@5.5.4)
+      cosmiconfig: 8.3.6(typescript@5.6.2)
+      cosmiconfig-typescript-loader: 5.0.0(@types/node@20.10.0)(cosmiconfig@8.3.6(typescript@5.6.2))(typescript@5.6.2)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -4044,13 +4044,13 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.5.4))(eslint@8.54.0)(typescript@5.5.4)':
+  '@typescript-eslint/eslint-plugin@6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.6.2))(eslint@8.54.0)(typescript@5.6.2)':
     dependencies:
       '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 6.11.0(eslint@8.54.0)(typescript@5.5.4)
+      '@typescript-eslint/parser': 6.11.0(eslint@8.54.0)(typescript@5.6.2)
       '@typescript-eslint/scope-manager': 6.11.0
-      '@typescript-eslint/type-utils': 6.11.0(eslint@8.54.0)(typescript@5.5.4)
-      '@typescript-eslint/utils': 6.11.0(eslint@8.54.0)(typescript@5.5.4)
+      '@typescript-eslint/type-utils': 6.11.0(eslint@8.54.0)(typescript@5.6.2)
+      '@typescript-eslint/utils': 6.11.0(eslint@8.54.0)(typescript@5.6.2)
       '@typescript-eslint/visitor-keys': 6.11.0
       debug: 4.3.6
       eslint: 8.54.0
@@ -4058,22 +4058,22 @@ snapshots:
       ignore: 5.3.1
       natural-compare: 1.4.0
       semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.5.4)
+      ts-api-utils: 1.3.0(typescript@5.6.2)
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.5.4)':
+  '@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.6.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 6.11.0
       '@typescript-eslint/types': 6.11.0
-      '@typescript-eslint/typescript-estree': 6.11.0(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 6.11.0(typescript@5.6.2)
       '@typescript-eslint/visitor-keys': 6.11.0
       debug: 4.3.6
       eslint: 8.54.0
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
@@ -4082,21 +4082,21 @@ snapshots:
       '@typescript-eslint/types': 6.11.0
       '@typescript-eslint/visitor-keys': 6.11.0
 
-  '@typescript-eslint/type-utils@6.11.0(eslint@8.54.0)(typescript@5.5.4)':
+  '@typescript-eslint/type-utils@6.11.0(eslint@8.54.0)(typescript@5.6.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.11.0(typescript@5.5.4)
-      '@typescript-eslint/utils': 6.11.0(eslint@8.54.0)(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 6.11.0(typescript@5.6.2)
+      '@typescript-eslint/utils': 6.11.0(eslint@8.54.0)(typescript@5.6.2)
       debug: 4.3.6
       eslint: 8.54.0
-      ts-api-utils: 1.3.0(typescript@5.5.4)
+      ts-api-utils: 1.3.0(typescript@5.6.2)
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@6.11.0': {}
 
-  '@typescript-eslint/typescript-estree@6.11.0(typescript@5.5.4)':
+  '@typescript-eslint/typescript-estree@6.11.0(typescript@5.6.2)':
     dependencies:
       '@typescript-eslint/types': 6.11.0
       '@typescript-eslint/visitor-keys': 6.11.0
@@ -4104,20 +4104,20 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.5.4)
+      ts-api-utils: 1.3.0(typescript@5.6.2)
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@6.11.0(eslint@8.54.0)(typescript@5.5.4)':
+  '@typescript-eslint/utils@6.11.0(eslint@8.54.0)(typescript@5.6.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.54.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 6.11.0
       '@typescript-eslint/types': 6.11.0
-      '@typescript-eslint/typescript-estree': 6.11.0(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 6.11.0(typescript@5.6.2)
       eslint: 8.54.0
       semver: 7.6.3
     transitivePeerDependencies:
@@ -4479,21 +4479,21 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cosmiconfig-typescript-loader@5.0.0(@types/node@20.10.0)(cosmiconfig@8.3.6(typescript@5.5.4))(typescript@5.5.4):
+  cosmiconfig-typescript-loader@5.0.0(@types/node@20.10.0)(cosmiconfig@8.3.6(typescript@5.6.2))(typescript@5.6.2):
     dependencies:
       '@types/node': 20.10.0
-      cosmiconfig: 8.3.6(typescript@5.5.4)
+      cosmiconfig: 8.3.6(typescript@5.6.2)
       jiti: 1.21.6
-      typescript: 5.5.4
+      typescript: 5.6.2
 
-  cosmiconfig@8.3.6(typescript@5.5.4):
+  cosmiconfig@8.3.6(typescript@5.6.2):
     dependencies:
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.6.2
 
   create-jest@29.7.0(@types/node@20.10.0):
     dependencies:
@@ -4738,17 +4738,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint@8.54.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint@8.54.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 6.11.0(eslint@8.54.0)(typescript@5.5.4)
+      '@typescript-eslint/parser': 6.11.0(eslint@8.54.0)(typescript@5.6.2)
       eslint: 8.54.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.5.4))(eslint@8.54.0):
+  eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.6.2))(eslint@8.54.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -4758,7 +4758,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.54.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint@8.54.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint@8.54.0)
       hasown: 2.0.2
       is-core-module: 2.15.0
       is-glob: 4.0.3
@@ -4769,7 +4769,7 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 6.11.0(eslint@8.54.0)(typescript@5.5.4)
+      '@typescript-eslint/parser': 6.11.0(eslint@8.54.0)(typescript@5.6.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -4779,12 +4779,12 @@ snapshots:
     dependencies:
       eslint: 8.54.0
 
-  eslint-plugin-unused-imports@3.0.0(@typescript-eslint/eslint-plugin@6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.5.4))(eslint@8.54.0)(typescript@5.5.4))(eslint@8.54.0):
+  eslint-plugin-unused-imports@3.0.0(@typescript-eslint/eslint-plugin@6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.6.2))(eslint@8.54.0)(typescript@5.6.2))(eslint@8.54.0):
     dependencies:
       eslint: 8.54.0
       eslint-rule-composer: 0.3.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.5.4))(eslint@8.54.0)(typescript@5.5.4)
+      '@typescript-eslint/eslint-plugin': 6.11.0(@typescript-eslint/parser@6.11.0(eslint@8.54.0)(typescript@5.6.2))(eslint@8.54.0)(typescript@5.6.2)
 
   eslint-rule-composer@0.3.0: {}
 
@@ -6510,9 +6510,9 @@ snapshots:
 
   trim-newlines@3.0.1: {}
 
-  ts-api-utils@1.3.0(typescript@5.5.4):
+  ts-api-utils@1.3.0(typescript@5.6.2):
     dependencies:
-      typescript: 5.5.4
+      typescript: 5.6.2
 
   ts-expose-internals-conditionally@1.0.0-empty.0: {}
 
@@ -6523,9 +6523,9 @@ snapshots:
       '@ts-morph/common': 0.24.0
       code-block-writer: 13.0.2
 
-  tsc-files@1.1.4(typescript@5.5.4):
+  tsc-files@1.1.4(typescript@5.6.2):
     dependencies:
-      typescript: 5.5.4
+      typescript: 5.6.2
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -6534,7 +6534,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tsup@8.0.0(@swc/core@1.3.107)(typescript@5.5.4):
+  tsup@8.0.0(@swc/core@1.3.107)(typescript@5.6.2):
     dependencies:
       bundle-require: 4.2.1(esbuild@0.19.12)
       cac: 6.7.14
@@ -6552,7 +6552,7 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       '@swc/core': 1.3.107
-      typescript: 5.5.4
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -6611,7 +6611,7 @@ snapshots:
 
   typescript@5.3.3: {}
 
-  typescript@5.5.4: {}
+  typescript@5.6.2: {}
 
   unbox-primitive@1.0.2:
     dependencies:

--- a/src/TypesService.ts
+++ b/src/TypesService.ts
@@ -359,6 +359,7 @@ function sharedConfig(
               module: ts.ModuleKind.Node16,
               target: ts.ScriptTarget.ESNext,
               stripInternal: true,
+              noEmitOnError: true,
               ...config.dtsCompilerOverrides,
             },
             fileSystem: host,


### PR DESCRIPTION
TypeScript will now properly report errors, before errors weren't collected because `noEmitOnError` was not set.