### PR TITLE
Make source maps configurable, source files have their own folder

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1727802920,
+        "narHash": "sha256-HP89HZOT0ReIbI7IJZJQoJgxvB2Tn28V6XS3MNKnfLs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "27e30d177e57d912d614c88c622dcfdb2e6e6515",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "A shell environment for building and testing build-tools";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { nixpkgs, ... }:
+    let
+      forAllSystems = function:
+        nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed
+          (system: function nixpkgs.legacyPackages.${system});
+    in
+    {
+      formatter = forAllSystems (pkgs: pkgs.alejandra);
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages = with pkgs; [
+            pnpm
+            nodejs_22
+          ];
+        };
+      });
+    };
+}

--- a/src/ConfigService.ts
+++ b/src/ConfigService.ts
@@ -87,6 +87,15 @@ export type ConfigParameters = {
   readonly srcDir?: string
 
   /**
+   * Whether to copy the source-directory to "source-files," along with declaration maps.
+   * This allows consumers of the library to control-click in VsCode or go-to-source and
+   * be taken to the raw source of the library.
+   *
+   * @default true
+   */
+  readonly emitDeclarationMaps?: boolean
+
+  /**
    * A list of package.json keys to omit from the copied file in dist
    *
    * @default ['devDependencies', 'scripts', 'lint-staged']
@@ -147,11 +156,13 @@ export class ConfigService {
     dtsConfig = 'tsconfig.json',
     dtsCompilerOverrides = {},
     bin = null,
+    emitDeclarationMaps = true,
   }: ConfigParameters) {
     this[ConfigServiceSymbol] = {
       buildType,
       srcDir,
       omittedPackageKeys,
+      emitDeclarationMaps,
       dtsConfig,
       copyFiles,
       basePath,

--- a/src/TypesService.ts
+++ b/src/TypesService.ts
@@ -351,7 +351,7 @@ function sharedConfig(
               emitDeclarationOnly: true,
               sourceMap: true,
               declaration: true,
-              declarationMap: true,
+              declarationMap: config.emitDeclarationMaps,
               noEmit: false,
               rootDir: config.basePath,
               outDir: path.join(config.basePath, config.outDir),


### PR DESCRIPTION
There was an issue with NextJS where it was typechecking all TypeScript files, even if they weren't part of the package export.  This moves the source files emitted while using build-tools to their own directory "source-files" in hopes that the name collision between a TypeScript file and a declaration file can be avoided.